### PR TITLE
Filter device groups and project names returned from server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
 group = 'com.testdroid'
 archivesBaseName = 'gradle'
-version = '2.100.0'
+version = '2.100.1'
 
 // custom tasks for creating source/javadoc jars
 task sourcesJar(type: Jar, dependsOn:classes) {

--- a/src/main/groovy/com/testdroid/TestDroidServer.java
+++ b/src/main/groovy/com/testdroid/TestDroidServer.java
@@ -137,7 +137,9 @@ public class TestDroidServer extends TestServer {
     private APIProject findProject(APIUser user, String projectName) throws APIException{
         final Context<APIProject> context = new Context<>(APIProject.class, 0, MAX_VALUE, EMPTY, EMPTY);
         context.addFilter(new FilterEntry(NAME, EQ, projectName));
-        return user.getProjectsResource(context).getEntity().getData().stream().findFirst()
+        return user.getProjectsResource(context).getEntity().getData().stream()
+                .filter(project -> project.getName().equals(projectName))
+                .findFirst()
                 .orElseThrow(() -> new InvalidUserDataException("TESTDROID: Can't find project " + projectName));
     }
 

--- a/src/main/groovy/com/testdroid/TestDroidServer.java
+++ b/src/main/groovy/com/testdroid/TestDroidServer.java
@@ -93,6 +93,7 @@ public class TestDroidServer extends TestServer {
             context.addFilter(new FilterEntry(DISPLAY_NAME, EQ, extension.getDeviceGroup()));
 
             APIDeviceGroup deviceGroup = user.getDeviceGroupsResource(context).getEntity().getData().stream()
+                    .filter(apiDeviceGroup -> apiDeviceGroup.getDisplayName().equals(extension.getDeviceGroup()))
                     .findFirst()
                     .orElseThrow(() -> new InvalidUserDataException("TESTDROID: Can't find device group " + extension
                             .getDeviceGroup()));


### PR DESCRIPTION
On older versions of BitBar server the query to server can return more device groups than was requested. In such case, the first picked device group might be not the same as the one requested by client in the plugin extension. The same problem is applicable for project names, so BitBar can create builds under a wrong project.