### PR TITLE
Use java-gradle-plugin for testdroid plugin compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'groovy'
 apply plugin: 'idea'
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply plugin: 'java-gradle-plugin'
 
 repositories {
     mavenCentral()
@@ -26,6 +27,15 @@ dependencies {
 group = 'com.testdroid'
 archivesBaseName = 'gradle'
 version = '2.100.1'
+
+gradlePlugin {
+    plugins {
+        testdroid {
+            id = 'testdroid'
+            implementationClass = 'com.testdroid.TestDroidPlugin'
+        }
+    }
+}
 
 // custom tasks for creating source/javadoc jars
 task sourcesJar(type: Jar, dependsOn:classes) {

--- a/src/main/resources/META-INF/gradle-plugins/testdroid.properties
+++ b/src/main/resources/META-INF/gradle-plugins/testdroid.properties
@@ -1,1 +1,0 @@
-implementation-class=com.testdroid.TestDroidPlugin


### PR DESCRIPTION
The java-gradle-plugin allows to specify "id" and "implementationClass" for a Gradle plugin inside build.gradle.  
Also, when maven-publish plugin is used for publication, it will configure publications accordingly, so the "marker" will be published for the plugin. The marker allows later to use the testdroid plugin in "plugins" configuration block of other Gradle projects.
In addition, the  java-gradle-plugin makes it easier to setup publication of the testdroid plugin to the official Gradle plugins portal.