### PR TITLE
Fix signing being skipped during Jenkins build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,6 @@ publishing {
 }
 
 signing {
-    required { gradle.taskGraph.hasTask("uploadArchives") }
+    required { gradle.taskGraph.hasTask(":publishMavenJavaPublicationToMavenRepository") }
     sign publishing.publications.mavenJava
 }


### PR DESCRIPTION
publishMavenJavaPublicationToMavenRepository is being run in Jenkinsfile at "deploy" stage.